### PR TITLE
Small Performance Improvements

### DIFF
--- a/src/main/java/de/uni_jena/cs/fusion/similarity/jarowinkler/LinkedListTrieMap.java
+++ b/src/main/java/de/uni_jena/cs/fusion/similarity/jarowinkler/LinkedListTrieMap.java
@@ -25,7 +25,6 @@ import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -49,7 +48,7 @@ class LinkedListTrieMap<V> implements Trie<V> {
 
 	// navigation
 	private LinkedListTrieMap<V> parent = null;
-	private List<LinkedListTrieMap<V>> children = new LinkedList<LinkedListTrieMap<V>>();
+	private List<LinkedListTrieMap<V>> children = new ArrayList<LinkedListTrieMap<V>>();
 	private List<? extends Trie<V>> childrenUnmodifiable = Collections.unmodifiableList(children);
 
 	// performance

--- a/src/main/java/de/uni_jena/cs/fusion/similarity/jarowinkler/Tries.java
+++ b/src/main/java/de/uni_jena/cs/fusion/similarity/jarowinkler/Tries.java
@@ -248,23 +248,7 @@ class Tries {
 	}
 
 	private static <K, V> Entry<K, V> mapEntry(K k, V v) {
-		return new Map.Entry<K, V>() {
-
-			@Override
-			public K getKey() {
-				return k;
-			}
-
-			@Override
-			public V getValue() {
-				return v;
-			}
-
-			@Override
-			public V setValue(V value) {
-				throw new UnsupportedOperationException();
-			}
-		};
+    return new AbstractMap.SimpleEntry<K, V>(k, v);
 	}
 
 	protected static <E> Iterator<E> singletonIterator(E element) {


### PR DESCRIPTION
* replace `LinkedList` by `ArrayList`
* replace returning a separate, custom `MapEntry` class each time by an instance of the default  class

Both changes together provided a 10%-20% increased performance in my local tests.